### PR TITLE
Properly applies styles to `T::Sig::WithoutRuntime`

### DIFF
--- a/script/byesig.js
+++ b/script/byesig.js
@@ -6,8 +6,9 @@ const byesig = (function () {
   const COMMAND_UNFOLD_ALL = 'editor.unfoldAll';
   // @FIXME: Don't match with empty block. Empty block is not foldable by default and as such, folding
   // will affect the parent block - which we do not want.
-  const RE_SIG_BLOCK = "^ *sig do$.*?^ *end\s*$";
-  const RE_SIG_LINE = "^ *sig {.*?}.*?$";
+  const RE_SIG_PREFIX = "^ *(T::Sig::WithoutRuntime\.)?sig";
+  const RE_SIG_BLOCK = `${RE_SIG_PREFIX} do$.*?^ *end\s*$`;
+  const RE_SIG_LINE = `${RE_SIG_PREFIX} {.*?}.*?$`;
 
   const FORCE = true;
 


### PR DESCRIPTION
Closes https://github.com/itarato/byesig/issues/11. This was a matter of updating the regex used to detect the `sig`. Since this pattern is getting complex, I moved the prefix (everything up to and including `sig`) into a constant. I decided not to put this behind a setting because it seemed like overkill.

I didn't see any tests in this project, so I tested this locally (see screenshots below). I also don't see anything about contribution guidelines, so let me know if there's anything I missed.

| Before | After |
|---|---|
|<img width="296" alt="byesig_before" src="https://user-images.githubusercontent.com/2320362/203430982-24cd381d-f3cb-491c-9c66-1eaf7223d025.png">|<img width="271" alt="byesig_after" src="https://user-images.githubusercontent.com/2320362/203431149-8b8d9723-eae5-4b44-b25b-e27b5b33ab8a.png">|