### PR TITLE
Include regex to match final method sig prefix

### DIFF
--- a/script/byesig.js
+++ b/script/byesig.js
@@ -6,7 +6,7 @@ const byesig = (function () {
   const COMMAND_UNFOLD_ALL = 'editor.unfoldAll';
   // @FIXME: Don't match with empty block. Empty block is not foldable by default and as such, folding
   // will affect the parent block - which we do not want.
-  const RE_SIG_PREFIX = "^ *(T::Sig::WithoutRuntime\.)?sig";
+  const RE_SIG_PREFIX = "^ *(T::Sig::WithoutRuntime\.)?sig(\(:final\))?";
   const RE_SIG_BLOCK = `${RE_SIG_PREFIX} do$.*?^ *end\s*$`;
   const RE_SIG_LINE = `${RE_SIG_PREFIX} {.*?}.*?$`;
 


### PR DESCRIPTION
This change updates the regex for the sig prefix to also match when the signature is for a [final method](https://sorbet.org/docs/final). 

<img width="360" alt="Screenshot 2024-02-14 at 12 05 58 PM" src="https://github.com/itarato/byesig/assets/8271325/b76dac86-a898-413c-a6a5-65efcb0ddd7f">
