### PR TITLE
Add toggle command

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,10 @@
 			{
 				"command": "byesig.showSig",
 				"title": "ByeSig: show Sorbet signatures"
+			},
+			{
+				"command": "byesig.toggleSig",
+				"title": "ByeSig: toggle Sorbet signatures"
 			}
 		],
 		"configuration": {

--- a/script/byesig.js
+++ b/script/byesig.js
@@ -156,6 +156,16 @@ const byesig = (function () {
     showAndUnfoldSig();
   }
 
+  function onCommandToggleSig() {
+    if (temporaryDisable) {
+      temporaryDisable = false;
+      hideAndFoldSig(FORCE);
+    } else {
+      temporaryDisable = true;
+      showAndUnfoldSig();
+    }
+  }
+
   /**
    * @param {import("vscode").TextDocument} textDoc
    */
@@ -198,6 +208,7 @@ const byesig = (function () {
   function activate(context) {
     context.subscriptions.push(vscode.commands.registerCommand('byesig.hideSig', onCommandHideAndFoldSig));
     context.subscriptions.push(vscode.commands.registerCommand('byesig.showSig', onCommandShowAndUnfoldSig));
+    context.subscriptions.push(vscode.commands.registerCommand('byesig.toggleSig', onCommandToggleSig));
     vscode.window.onDidChangeActiveTextEditor(() => { hideAndFoldSig(); }, null, context.subscriptions);
     vscode.workspace.onDidChangeTextDocument(delayedHideSig, null, context.subscriptions);
     vscode.workspace.onDidOpenTextDocument(onDidOpenTextDocument, null, context.subscriptions);


### PR DESCRIPTION
This pull request adds a new command to the ByeSig extension for toggling Sorbet signatures and updates the relevant files to support this feature.

New command addition:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R31-R34): Added a new command `byesig.toggleSig` to the command list.

Implementation of the new command:

* [`script/byesig.js`](diffhunk://#diff-07d27920f749831ef1fbf219c42070953285286df804832fddf13fa69308b5f4R159-R168): Added the `onCommandToggleSig` function to handle the toggling of Sorbet signatures.
* [`script/byesig.js`](diffhunk://#diff-07d27920f749831ef1fbf219c42070953285286df804832fddf13fa69308b5f4R211): Registered the new `byesig.toggleSig` command in the `activate` function.